### PR TITLE
Updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.1"
-          gleam-version: "0.32.2"
+          otp-version: "28"
+          gleam-version: "1.11"
           rebar3-version: "3"
       - run: gleam deps download
       - run: gleam test

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,16 +4,15 @@ licences = ["Apache-2.0"]
 description = "Send emails from Gleam with SendGrid"
 repository = { type = "github", user = "lpil", repo = "gleam_sendgrid" }
 links = [
-  { title = "Website", href = "https://gleam.run" },
-  { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
+    { title = "Website", href = "https://gleam.run" },
+    { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
-gleam = ">= 0.32.0"
+gleam = ">= 1.11.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.19"
-gleam_http = "~> 3.0"
-gleam_json = "~> 0.4"
+gleam_json = ">= 3.0.2 and < 4.0.0"
+gleam_http = ">= 4.1.0 and < 5.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
-gleam_hackney = "~> 1.0"
+gleeunit = ">= 1.6.0 and < 2.0.0"
+gleam_hackney = ">= 1.3.1 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,8 +4,8 @@ licences = ["Apache-2.0"]
 description = "Send emails from Gleam with SendGrid"
 repository = { type = "github", user = "lpil", repo = "gleam_sendgrid" }
 links = [
-    { title = "Website", href = "https://gleam.run" },
-    { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
+  { title = "Website", href = "https://gleam.run" },
+  { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
 gleam = ">= 1.11.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,25 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
-  { name = "gleam_hackney", version = "1.1.0", build_tools = ["gleam"], requirements = ["hackney", "gleam_http", "gleam_stdlib"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "CA69AD9061C4A8775A7BD445DE33ECEFD87379AF8E5B028F3DD0216BECA5DD0B" },
-  { name = "gleam_http", version = "3.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0B09AAE8EB547C4F2F2D3F8917A0A4D2EF75DFF0232389332BAFE19DBBFDB92B" },
-  { name = "gleam_json", version = "0.7.0", build_tools = ["gleam"], requirements = ["thoas", "gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB405BD93A8828BCD870463DE29375E7B2D252D9D124C109E5B618AAC00B86FC" },
-  { name = "gleam_stdlib", version = "0.32.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "07D64C26D014CF570F8ACADCE602761EA2E74C842D26F2FD49B0D61973D9966F" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
-  { name = "hackney", version = "1.20.1", build_tools = ["rebar3"], requirements = ["idna", "parse_trans", "certifi", "unicode_util_compat", "metrics", "mimerl", "ssl_verify_fun"], otp_app = "hackney", source = "hex", outer_checksum = "FE9094E5F1A2A2C0A7D10918FEE36BFEC0EC2A979994CFF8CFE8058CD9AF38E3" },
+  { name = "certifi", version = "2.15.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "B147ED22CE71D72EAFDAD94F055165C1C182F61A2FF49DF28BCC71D1D5B94A60" },
+  { name = "gleam_hackney", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "0449AADBEBF3E979509A4079EE34B92EEE4162C5A0DC94F3DA2787E4777F6B45" },
+  { name = "gleam_http", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "DB25DFC8530B64B77105405B80686541A0D96F7E2D83D807D6B2155FB9A8B1B8" },
+  { name = "gleam_json", version = "3.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "874FA3C3BB6E22DD2BB111966BD40B3759E9094E05257899A7C08F5DE77EC049" },
+  { name = "gleam_stdlib", version = "0.62.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DC8872BC0B8550F6E22F0F698CFE7F1E4BDA7312FDEB40D6C3F44C5B706C8310" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
+  { name = "hackney", version = "1.24.1", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "F4A7392A0B53D8BBC3EB855BDCC919CD677358E65B2AFD3840B5B3690C4C8A39" },
   { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
-  { name = "mimerl", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "F278585650AA581986264638EBF698F8BB19DF297F66AD91B18910DFC6E19323" },
+  { name = "mimerl", version = "1.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "13AF15F9F68C65884ECCA3A3891D50A7B57D82152792F3E19D88650AA126B144" },
   { name = "parse_trans", version = "3.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "620A406CE75DADA827B82E453C19CF06776BE266F5A67CFF34E1EF2CBB60E49A" },
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
-  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
-  { name = "unicode_util_compat", version = "0.7.0", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "25EEE6D67DF61960CF6A794239566599B09E17E668D3700247BC498638152521" },
+  { name = "unicode_util_compat", version = "0.7.1", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "B3A917854CE3AE233619744AD1E0102E05673136776FB2FA76234F3E03B23642" },
 ]
 
 [requirements]
-gleam_hackney = { version = "~> 1.0" }
-gleam_http = { version = "~> 3.0" }
-gleam_json = { version = "~> 0.4" }
-gleam_stdlib = { version = "~> 0.19" }
-gleeunit = { version = "~> 1.0" }
+gleam_hackney = { version = ">= 1.3.1 and < 2.0.0" }
+gleam_http = { version = ">= 4.1.0 and < 5.0.0" }
+gleam_json = { version = ">= 3.0.2 and < 4.0.0" }
+gleeunit = { version = ">= 1.6.0 and < 2.0.0" }

--- a/test/gleam/sendgrid_integration_test.gleam
+++ b/test/gleam/sendgrid_integration_test.gleam
@@ -1,7 +1,6 @@
-import gleam/sendgrid
 import gleam/hackney
+import gleam/sendgrid
 
-// pub fn main_test() {
 pub fn main() {
   let api_key = "nope"
 

--- a/test/gleam/sendgrid_test.gleam
+++ b/test/gleam/sendgrid_test.gleam
@@ -1,7 +1,6 @@
-import gleam/sendgrid
 import gleam/http
 import gleam/http/request
-import gleeunit/should
+import gleam/sendgrid
 
 pub fn dispatch_request_text_content_test() {
   let request =
@@ -14,27 +13,15 @@ pub fn dispatch_request_text_content_test() {
     )
     |> sendgrid.dispatch_request("some-api-key")
 
-  request.host
-  |> should.equal("api.sendgrid.com")
-
-  request.path
-  |> should.equal("/v3/mail/send")
-
-  request.method
-  |> should.equal(http.Post)
-
-  request
-  |> request.get_header("content-type")
-  |> should.equal(Ok("application/json"))
-
-  request
-  |> request.get_header("authorization")
-  |> should.equal(Ok("Bearer some-api-key"))
-
-  request.body
-  |> should.equal(
-    "{\"personalizations\":[{\"to\":[{\"email\":\"joe@example.com\"}]}],\"from\":{\"email\":\"mike@example.com\",\"name\":\"Mike\"},\"subject\":\"Hello, Joe!\",\"content\":[{\"type\":\"text/plain\",\"value\":\"System still working?\"}]}",
-  )
+  assert http.Post == request.method
+  assert http.Https == request.scheme
+  assert "api.sendgrid.com" == request.host
+  assert "/v3/mail/send" == request.path
+  assert Ok("application/json") == request.get_header(request, "content-type")
+  assert Ok("Bearer some-api-key")
+    == request.get_header(request, "authorization")
+  assert "{\"personalizations\":[{\"to\":[{\"email\":\"joe@example.com\"}]}],\"from\":{\"email\":\"mike@example.com\",\"name\":\"Mike\"},\"subject\":\"Hello, Joe!\",\"content\":[{\"type\":\"text/plain\",\"value\":\"System still working?\"}]}"
+    == request.body
 }
 
 pub fn dispatch_request_rich_content_test() {
@@ -51,25 +38,13 @@ pub fn dispatch_request_rich_content_test() {
     )
     |> sendgrid.dispatch_request("some-api-key")
 
-  request.host
-  |> should.equal("api.sendgrid.com")
-
-  request.path
-  |> should.equal("/v3/mail/send")
-
-  request.method
-  |> should.equal(http.Post)
-
-  request
-  |> request.get_header("content-type")
-  |> should.equal(Ok("application/json"))
-
-  request
-  |> request.get_header("authorization")
-  |> should.equal(Ok("Bearer some-api-key"))
-
-  request.body
-  |> should.equal(
-    "{\"personalizations\":[{\"to\":[{\"email\":\"joe@example.com\"}]}],\"from\":{\"email\":\"mike@example.com\",\"name\":\"Mike\"},\"subject\":\"Hello, Joe!\",\"content\":[{\"type\":\"text/plain\",\"value\":\"System still working?\"},{\"type\":\"text/html\",\"value\":\"<p>System still working?</p>\"}]}",
-  )
+  assert http.Post == request.method
+  assert http.Https == request.scheme
+  assert "api.sendgrid.com" == request.host
+  assert "/v3/mail/send" == request.path
+  assert Ok("application/json") == request.get_header(request, "content-type")
+  assert Ok("Bearer some-api-key")
+    == request.get_header(request, "authorization")
+  assert "{\"personalizations\":[{\"to\":[{\"email\":\"joe@example.com\"}]}],\"from\":{\"email\":\"mike@example.com\",\"name\":\"Mike\"},\"subject\":\"Hello, Joe!\",\"content\":[{\"type\":\"text/plain\",\"value\":\"System still working?\"},{\"type\":\"text/html\",\"value\":\"<p>System still working?</p>\"}]}"
+    == request.body
 }


### PR DESCRIPTION
This PR:
- updates the `gleam_http` and `gleam_json` dependencies to their latest major version
- drops the direct dependency on `gleam_stdlib`
- in general brings the package up to date with the latest gleam version, most notably:
  - I've used the label shorthand syntax where possible
  - I've used `assert` to replace the `should.equal` assertions 