### PR TITLE
Update existing API, add response decoder

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,6 +12,7 @@ gleam = ">= 1.11.0"
 [dependencies]
 gleam_json = ">= 3.0.2 and < 4.0.0"
 gleam_http = ">= 4.1.0 and < 5.0.0"
+gleam_stdlib = ">= 0.62.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.6.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -21,4 +21,5 @@ packages = [
 gleam_hackney = { version = ">= 1.3.1 and < 2.0.0" }
 gleam_http = { version = ">= 4.1.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.2 and < 4.0.0" }
+gleam_stdlib = { version = ">= 0.62.0 and < 1.0.0" }
 gleeunit = { version = ">= 1.6.0 and < 2.0.0" }

--- a/src/gleam/sendgrid.gleam
+++ b/src/gleam/sendgrid.gleam
@@ -4,9 +4,23 @@ import gleam/json
 
 pub type Email {
   Email(
+    /// A list of emails to whom this email will be sent.
+    ///
     to: List(String),
-    sender_name: String,
+    /// The email address from which messages are sent, it should be a verified
+    /// sender in your Twilio SendGrid account.
+    ///
     sender_email: String,
+    /// A name or title associated with the email address such as "Support" or
+    /// "Alice".
+    ///
+    sender_name: String,
+    /// The subject of your email.
+    ///
+    /// > Note how, as per [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822#section-2.1.1),
+    /// > the subject line should be no more than 78 characters, and must be no
+    /// > more than 998 characters.
+    ///
     subject: String,
     content: EmailContent,
   )
@@ -17,14 +31,8 @@ pub type EmailContent {
   RichContent(html: String, text: String)
 }
 
-// TODO: test
-// TODO: documents
-// curl --request POST \
-//   --url https://api.sendgrid.com/v3/mail/send \
-//   --header "Authorization: Bearer $SENDGRID_API_KEY" \
-//   --header 'Content-Type: application/json' \
-//   --data '{"personalizations": [{"to": [{"email": "test@example.com"}]}],"from": {"email": "test@example.com"},"subject": "Sending with SendGrid is Fun","content": [{"type": "text/plain", "value": "and easy to do anywhere, even with cURL"}]}'
-pub fn dispatch_request(email: Email, api_key: String) -> Request(String) {
+/// A request to send email over SendGrid's v3 Web API.
+///
 pub fn mail_send_request(email: Email, api_key: String) -> Request(String) {
   let Email(to:, sender_name:, sender_email:, subject:, content:) = email
 

--- a/src/gleam/sendgrid.gleam
+++ b/src/gleam/sendgrid.gleam
@@ -25,6 +25,7 @@ pub type EmailContent {
 //   --header 'Content-Type: application/json' \
 //   --data '{"personalizations": [{"to": [{"email": "test@example.com"}]}],"from": {"email": "test@example.com"},"subject": "Sending with SendGrid is Fun","content": [{"type": "text/plain", "value": "and easy to do anywhere, even with cURL"}]}'
 pub fn dispatch_request(email: Email, api_key: String) -> Request(String) {
+pub fn mail_send_request(email: Email, api_key: String) -> Request(String) {
   let Email(to:, sender_name:, sender_email:, subject:, content:) = email
 
   let make_email = fn(email) { json.object([#("email", json.string(email))]) }

--- a/test/gleam/sendgrid_integration_test.gleam
+++ b/test/gleam/sendgrid_integration_test.gleam
@@ -21,5 +21,5 @@ pub fn main() {
   let assert Ok(response) = hackney.send(request)
 
   // A status of 202 indicates that the email has been sent
-  let assert 202 = response.status
+  assert 202 == response.status
 }

--- a/test/gleam/sendgrid_integration_test.gleam
+++ b/test/gleam/sendgrid_integration_test.gleam
@@ -15,7 +15,7 @@ pub fn main() {
     )
 
   // Prepare an API request
-  let request = sendgrid.dispatch_request(email, api_key)
+  let request = sendgrid.mail_send_request(email, api_key)
 
   // Send it with a HTTP client of your choice
   let assert Ok(response) = hackney.send(request)

--- a/test/gleam/sendgrid_test.gleam
+++ b/test/gleam/sendgrid_test.gleam
@@ -11,7 +11,7 @@ pub fn dispatch_request_text_content_test() {
       subject: "Hello, Joe!",
       content: sendgrid.TextContent("System still working?"),
     )
-    |> sendgrid.dispatch_request("some-api-key")
+    |> sendgrid.mail_send_request("some-api-key")
 
   assert http.Post == request.method
   assert http.Https == request.scheme
@@ -36,7 +36,7 @@ pub fn dispatch_request_rich_content_test() {
         text: "System still working?",
       ),
     )
-    |> sendgrid.dispatch_request("some-api-key")
+    |> sendgrid.mail_send_request("some-api-key")
 
   assert http.Post == request.method
   assert http.Https == request.scheme


### PR DESCRIPTION
Hello! With this PR I have:
- renamed `dispatch_request` to `mail_send_request`
- added some documentation comments
- added a decoder for responses coming form the SendGrid api; I was not sure what the best approach would be, so I copied what `bucket` is doing. Let me know what you think!